### PR TITLE
Add spellchecker to CI and fix a spelling error

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -12,6 +12,9 @@ jobs:
     - name: Checkout 📋
       uses: actions/checkout@v2
 
+    - name: Run spellchecker
+      uses: crate-ci/typos@v1.19.0
+
     - name: Setup 🏗️
       run: |
         sudo apt-get install --yes xml2rfc ruby

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,13 @@
+[files]
+extend-exclude = [
+    ".devcontainer/",
+    ".git/",
+    ".github/",
+    "vendor/",
+]
+ignore-hidden = false
+
+
+[default.extend-words]
+# Secure Hash Standard
+"SHS" = "SHS"

--- a/draft-ietf-acme-scoped-dns-challenges.mkd
+++ b/draft-ietf-acme-scoped-dns-challenges.mkd
@@ -151,7 +151,7 @@ On receiving a response, the server constructs and stores the key authorization 
 To validate the `dns-02` challenge, the server performs the following steps:
 
 - Compute the SHA-256 digest {{FIPS180-4}} of the stored key authorization
-- Compute the validation domain name with the scope of the associated authorization similiar to the client
+- Compute the validation domain name with the scope of the associated authorization similar to the client
 - Query for `TXT` records for the validation domain name
 - Verify that the contents of one of the `TXT` records match the digest value
 


### PR DESCRIPTION
Fixes a spelling error: `similiar` to `similar`
Adds a [Rust spellchecker to github actions](https://github.com/marketplace/actions/typos-action) CI. The spellchecker incorporates various [dictionaries](https://github.com/crate-ci/typos/tree/a35b382b446be75ad3f5c5abc53ec36cd8c23b47/crates) used by similar tools..
