### PR TITLE
Change account resource URL to account URL

### DIFF
--- a/draft-ietf-acme-scoped-dns-challenges.mkd
+++ b/draft-ietf-acme-scoped-dns-challenges.mkd
@@ -78,7 +78,7 @@ The `dns-02` challenge adds onto `dns-01` by introducing a scoping mechanism to 
 
 ## DNS-ACCOUNT-01
 
-The `dns-account-01` challenge leverages the ACME Account Resource URL to present an account-unique stable challenge to an ACME server. This challenge allows any domain name to delegate its domain validation to more than one service through
+The `dns-account-01` challenge leverages the ACME account URL to present an account-unique stable challenge to an ACME server. This challenge allows any domain name to delegate its domain validation to more than one service through
 unique per ACME account DNS records.
 
 With this new challenge, domain validation of the same DNS name can be done through different authorization labels. Since these authorization labels will depend on the ACME account KID ({{!RFC8555, Section 6.2}}), any number of them can be generated in advance. This allows all required `CNAME` records for domain validation delegation to be constructed statically.
@@ -185,12 +185,12 @@ A client can fulfill this challenge by performing the following steps:
 - Compute the SHA-256 digest {{FIPS180-4}} of the key authorization
 - Construct the validation domain name by prepending the following two labels to the domain name being validated:
 
-      "_" || base32(SHA-256(<ACCOUNT_RESOURCE_URL>)[0:10]) || "._acme-" || <SCOPE> || "-challenge"
+      "_" || base32(SHA-256(<ACCOUNT_URL>)[0:10]) || "._acme-" || <SCOPE> || "-challenge"
 
    - SHA-256 is the SHA hashing operation defined in {{!RFC6234}}
    - `[0:10]` is the operation that selects the first ten bytes (bytes 0 through 9 inclusive) from the previous SHA-256 operation
    - base32 is the operation defined in {{!RFC4648}}
-   - ACCOUNT_RESOURCE_URL is defined in {{!RFC8555, Section 7.3}} as the value in the `Location` header field
+   - ACCOUNT_URL is defined in {{!RFC8555, Section 7.3}} as the value in the `Location` header field
    - SCOPE is
      - "host" if the associated authorization applies only to the specific host name and no labels beneath it
      - "wildcard" if the associated authorization is for a wildcard domain and contains the `wildcard` field set to true ({{?RFC8555, Section 7.1.4}})


### PR DESCRIPTION
RFC8555 has no mention of an "account resource URL", but does use the phrase "account URL" in several locations, notably [section 7.3](https://datatracker.ietf.org/doc/html/rfc8555#section-7.3).

> The server returns
>   this account object in a 201 (Created) response, with the account URL
>   in a Location header field.  The account URL is used as the "kid"
>   value in the JWS authenticating subsequent requests by this account